### PR TITLE
Update SciLabs CP120x VCP Driver URL

### DIFF
--- a/docs/installation/software.md
+++ b/docs/installation/software.md
@@ -54,7 +54,7 @@ Important:
 
 Requires macOS 10.12 or newer
 
-Please make sure that you have installed the [SiLabs CP210x "VCP" Driver](http://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx) - it is required for use with most new boards.
+Please make sure that you have installed the [SiLabs CP210x "VCP" Driver](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads) - it is required for use with most new boards.
 
 Download the DMG image from [ayab-knitting.com](https://ayab-knitting.com/ayab-software/), open the DMG image and drag&drop the app to your Application folder.
 Then run AYAB from your Application folder.


### PR DESCRIPTION
The previous url just links to the home page rather than the downloads page.