### PR TITLE
fix: fix ubuntu installation

### DIFF
--- a/docs/installation/software.md
+++ b/docs/installation/software.md
@@ -7,7 +7,7 @@ The other main dependencies can be found in requirements.txt
 
 *For Debian/Ubuntu*
 
-    sudo apt-get install python3-pip python3-dev python3-virtualenv python3-gi
+    sudo apt-get install python3-pip python3-dev python3-virtualenv python3-gi libasound2-dev
 
 *For openSUSE*
 


### PR DESCRIPTION
When trying the installation on my computer (Ubuntu 22.04.4 LTS), I had an error when installing the requirements:
```
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DDEBUG=0 -I/home/mathieu/Documents/projects/ayab-desktop/venv/include -I/home/mathieu/.pyenv/versions/3.11.9/include/python3.11 -c c_src/posix_mutex.c -o build/temp.linux-x86_64-cpython-311/c_src/posix_mutex.o
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DDEBUG=0 -I/home/mathieu/Documents/projects/ayab-desktop/venv/include -I/home/mathieu/.pyenv/versions/3.11.9/include/python3.11 -c c_src/simpleaudio.c -o build/temp.linux-x86_64-cpython-311/c_src/simpleaudio.o
      c_src/simpleaudio.c: In function ‘_play_buffer’:
      c_src/simpleaudio.c:164:5: warning: ‘PyEval_InitThreads’ is deprecated [-Wdeprecated-declarations]
        164 |     PyEval_InitThreads();
            |     ^~~~~~~~~~~~~~~~~~
      In file included from /home/mathieu/.pyenv/versions/3.11.9/include/python3.11/Python.h:95,
                       from c_src/simpleaudio.h:10,
                       from c_src/simpleaudio.c:7:
      /home/mathieu/.pyenv/versions/3.11.9/include/python3.11/ceval.h:132:37: note: declared here
        132 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
            |                                     ^~~~~~~~~~~~~~~~~~
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DDEBUG=0 -I/home/mathieu/Documents/projects/ayab-desktop/venv/include -I/home/mathieu/.pyenv/versions/3.11.9/include/python3.11 -c c_src/simpleaudio_alsa.c -o build/temp.linux-x86_64-cpython-311/c_src/simpleaudio_alsa.o
      c_src/simpleaudio_alsa.c:8:10: fatal error: alsa/asoundlib.h: Aucun fichier ou dossier de ce nom
          8 | #include <alsa/asoundlib.h>
            |          ^~~~~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for simpleaudio
``` 
I solved it by installing libasound2-dev