### PR TITLE
Document the 64 byte message size limit

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,6 +15,8 @@ Checksums are calculated using the CRC8 algorithm as implemented in Dallas/Maxim
 Messages are limited in size to **64** bytes, not including the SLIP packet markers (`0xC0`
 bytes), but taking into account the fact that under SLIP, data bytes equal to `0xC0` or `0xDB`
 are escaped into two bytes, the maximum safe payload size is **32** bytes.
+This value is defined in the MAX_MSG_BUFFER_LEN constant in AYAB firmware und should be adapted
+accordingly in case of API message length changes.
 
 ## Protocol for API v6
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,10 @@ Asynchronous serial communication at 115200 baud, 8N1 without hardware flow cont
 Checksums are calculated using the CRC8 algorithm as implemented in Dallas/Maxim application note
 27.
 
+Messages are limited in size to **64** bytes, not including the SLIP packet markers (`0xC0`
+bytes), but taking into account the fact that under SLIP, data bytes equal to `0xC0` or `0xDB`
+are escaped into two bytes, the maximum safe payload size is **32** bytes.
+
 ## Protocol for API v6
 
 ### API version check


### PR DESCRIPTION
This documents the message size limit proposed in https://github.com/AllYarnsAreBeautiful/ayab-firmware/pull/193 .

Any feedback on the formulation is welcome.