### PR TITLE
Auto-deploy version 1.0 alias dev from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,20 +4,19 @@ name: Deploy
 on:
   # Triggers the workflow on push events but only for the "master" branch
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       version:
-        description: 'Which Version of Docs to Deploy'
+        description: 'Which version of docs to deploy, including space-separated tags (e.g. "0.95 latest", "1.0 dev")'
         required: true
-        default: '0.95'
+        default: '1.0 dev'
         type: string
-        options:
-          - '0.95'
+
 env:
-  DEFAULT_VERSION: 0.95
+  DEFAULT_VERSION: '1.0 dev'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "deploy"
@@ -38,12 +37,6 @@ jobs:
         
       # Runs a set of commands using the runners shell
       - name: Run Mike
-        if: inputs.version
         run: |
           pip install -r requirements.txt
-          mike deploy ${{ inputs.version }} latest -u -p
-      - name: Run Mike Update
-        if: inputs.version == ''
-        run: |
-          pip install -r requirements.txt
-          mike deploy $DEFAULT_VERSION latest -u -p
+          mike deploy ${{ inputs.version || env.DEFAULT_VERSION }} -u -p


### PR DESCRIPTION
⚠️ As discussed on Discord, before merging this PR the `1.0` branch should be renamed to `main` for it to work.

This PR changes the `Deploy` workflow so that it triggers on every commit to `main`, and deploys a version named `1.0` aliased to `dev`.

The result on https://manual.ayab-knitting.com/ should be:
- the 0.95 version of the docs should still be the default;
- the version selector should offer 1.0 as an alternative version, that serves the content built from `main`.

Here's a preview of the result, built from this branch: https://code.jonathanperret.net/ayab-manual/ . One can check that the 1.0 docs have e.g. the start delay warning removed by #40: http://code.jonathanperret.net/ayab-manual/1.0/how_to_knit/basics/
