### PR TITLE
Update docs on garter carriage usage

### DIFF
--- a/docs/how_to_knit/garter_carriage.md
+++ b/docs/how_to_knit/garter_carriage.md
@@ -3,28 +3,41 @@
 ## Setup
 
 Make sure:
+
   - You're using the 1.0 desktop software and the latest firmware. The garter carriage is not supported in older versions.
   - Your garter carriage is compatible with your machine. [Compatibility chart](https://www.needlesofsteel.org.uk/compat-brother.html#garter)
   - You know how to use your garter carriage with your machine. You can find manuals at [MKManuals](https://mkmanuals.com/)
 
 ## Getting started
 
-Cast on either to waste yarn or your main yarn.
+1. Cast on with either waste yarn or your main yarn.
 
-Get the garter carriage set up and put it on the bed so that both sets of magnets are outside of the turn mark.
+2. Get the garter carriage set up and put it on the bed so that both sets of magnets on the back of the garter carriage are outside of the turn mark.
 
-Open your image in the AYAB desktop software. 
+3. Open your pattern image in the AYAB desktop software. 
 
-Click knit.
+4. Under Settings, select the start and stop needles that reflect the needles selected on the needle bed. If needed, use *Image Actions > Repeat* or *Image Actions > Stretch* to increase the size of your pattern to cover the required needles.
 
-Start the garter carriage. 
+5. Click Knit.
 
-When the first set of magnets has passed the turn mark, the desktop software should identify the garter carriage, load the pattern, and keep going.
+6. Take up any spare yarn slack in the yarn mast.
+
+7. Set the garter carriage row counter to the desired number of rows.
+
+8. Start the garter carriage. 
+
+9. When the first set of magnets has passed the turn mark, the desktop software should identify the garter carriage, load the pattern, and continue knitting until the garter carriage row counter reaches 0.
 
 ## Known Issue
+
+### Going to sleep during long operation
 
 The desktop software does not hold a wake lock so your computer won't stay awake. If your computer goes to sleep, it may mess up the patterning on your knitting machine.
 
 [WikiHow](https://www.wikihow.com/Keep-Your-Computer-Awake) has some instructions for how to keep your computer awake.
 
 You can also open a browser and play a YouTube video. As long as the browser is in the foreground and a video is playing, the computer will stay awake.
+
+### Carriage turns around before next row loaded
+
+Ensure the pattern and selected needles in the AYAB desktop software reflect the selected needles on the needle bed. If the pattern selected in the software is wider than the needles used, the carriage may try to turn around when it detects empty needles, before the next row of pattern information has been loaded. 


### PR DESCRIPTION
I had difficulty when I was first using my KG95 garter carriage with AYAB 1.0 and after talking it through with @jonathanperret on discord I realised that the software and hardware were working as intended, but there were some assumptions that weren't spelt out in the documentation regarding needle selection. This PR adds some more detail to the garter carriage doc page to help future users.